### PR TITLE
Upgrade to semver 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "right-now",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Get the quickest, most high-resolution timestamp possible in node or the browser",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
Annoying nit pick, but I want to switch game-shell to use this instead of the clumsy built in polyfill right now.  However, I am trying to make sure that going forward everything in the whole gl-\* dependency chain is semver compliant so that I can use "^" to handle upgrades.

Can you republish this module with a semver >=1.0.0?
